### PR TITLE
Xopen for compression

### DIFF
--- a/src/merge_files.py
+++ b/src/merge_files.py
@@ -267,7 +267,7 @@ def run_merge_files():
     # File handle for output
     # output_fn = dict_flags['--output'] + '.dose.vcf.gz' # Do not always need this dose suffix
     output_fn = dict_flags['--output'] + '.vcf.gz'
-    fh_output = PipedCompressionWriter(path=output_fn, threads_flag="-@", program_args=["bgzip", f"-I {output_fn}i"], threads=dict_flags['--thread'])
+    fh_output = PipedCompressionWriter(path=output_fn, threads_flag="-@", program_args=["bgzip", f"-I {output_fn}.gzi"], threads=dict_flags['--thread'])
 
     # 2. Merge header lines and write to output file (row 0-18 in this version (2021/07,v1))
     # Also Get index number of some columns:

--- a/src/merge_files.py
+++ b/src/merge_files.py
@@ -2,7 +2,7 @@
 # This code is used to merge imputed files from TopMed based on list of saved variants in prior steps
 # The goal is to combine post-imputation vcf.gz files into one vcf.gz file
 
-from xopen import xopen # Faster than gzip
+from xopen import PipedCompressionWriter, xopen # Faster than gzip
 # import sys
 import process_args
 import get_SNP_list
@@ -268,6 +268,7 @@ def run_merge_files():
     # output_fn = dict_flags['--output'] + '.dose.vcf.gz' # Do not always need this dose suffix
     output_fn = dict_flags['--output'] + '.vcf.gz'
     fh_output_raw = open(output_fn, 'wb')  # Open for writing (appending), use bgzip module later to write
+    PipedCompressionWriter(output_fn, threads_flag="--threads", program_args=["bgzip", "-i"])
     fh_output = bgzip.BGZipWriter(fh_output_raw)
 
     # 2. Merge header lines and write to output file (row 0-18 in this version (2021/07,v1))


### PR DESCRIPTION
This changes from using the bgzip python module to write output to using xopen's PipedCompressionWriter tool to open an external command line tool (bgzip) and write through that.

It also passes the threads flag directly to the external tool, and generates the index with .gzi after the file name.

We are also writing in text mode now, and do not have to manually encode text.